### PR TITLE
Providing bogus default value for OCI URL

### DIFF
--- a/charts/oci-secret/Chart.yaml
+++ b/charts/oci-secret/Chart.yaml
@@ -5,5 +5,5 @@
 apiVersion: v2
 name: oci-secret
 type: application
-version: 2.0.1
+version: 2.0.2
 appVersion: "1.0.0"

--- a/charts/oci-secret/values.yaml
+++ b/charts/oci-secret/values.yaml
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 remoteNamespace: orch-secret
-ociUrl: ""
+ociUrl: "default-oci-url"


### PR DESCRIPTION
It's used in the template as
```
        url: {{ required "A valid ociUrl entry required!" .Values.ociUrl }}
```
thus an empty string won't be enough