### PR TITLE
Set Dependabot interval to Monthly instead of Daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
       - "/nexus/compiler/example/output/generated/nexus-gql"
       - "/nexus/compiler/example/tests"
       - "/nexus/compiler/example/tests/custom_query_grpc_server"
-      - "/nexus/compil er/example/datamodel/build/nexus-gql"
+      - "/nexus/compiler/example/datamodel/build/nexus-gql"
       - "/nexus/compiler/example/datamodel"
       - "/nexus/common-library"
       - "/nexus/nexus"


### PR DESCRIPTION
### Description

If we want to bulk upgrade deps, we should manually do so first instead of having Dependabot do it since it can be expensive time/cost wise.

Fixes # (issue)

To reduce CI load.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
