### PR TITLE
ITEP-21376 Adding secure headers for App Orch

### DIFF
--- a/charts/traefik-extra-objects/Chart.yaml
+++ b/charts/traefik-extra-objects/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v1
 description: A Helm chart for Traefik extra objects.
 name: traefik-extra-objects
-version: 4.1.7
+version: 4.1.8
 appVersion: "1.0.0"

--- a/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
+++ b/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
@@ -401,6 +401,90 @@ spec:
       X-ruxit-JS-Agent: ""
 ---
 apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: secure-headers-app-orch
+  namespace: orch-gateway
+spec:
+  headers:
+    referrerPolicy: "no-referrer"
+    customResponseHeaders:
+      X-Permitted-Cross-Domain-Policies: none
+      Pragma: no-cache
+      Cache-Control: "no-store, max-age=0"
+      Content-Security-Policy: "
+        default-src 'self'; form-action 'self';
+        object-src 'none'; frame-ancestors 'none';
+        script-src 'self' ;
+        frame-src 'self' ;
+        style-src 'self'; img-src 'self' data:;
+        connect-src 'self' https://{{ required "A valid keycloak domain entry required!" .Values.keycloakMatchHost }};
+        upgrade-insecure-requests; block-all-mixed-content"
+      Cross-Origin-Embedder-Policy: unsafe-none
+      Cross-Origin-Opener-Policy: same-origin
+      Cross-Origin-Resource-Policy: same-origin
+      Permissions-Policy: "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()"
+      "$wsep": ""
+      Host-Header: ""
+      K-Proxy-Request: ""
+      Liferay-Portal: ""
+      OracleCommerceCloud-Version: ""
+      Pega-Host: ""
+      Powered-By: ""
+      Product: ""
+      Server: ""
+      SourceMap: ""
+      X-AspNet-Version: ""
+      X-AspNetMvc-Version: ""
+      X-Atmosphere-error: ""
+      X-Atmosphere-first-request: ""
+      X-Atmosphere-tracking-id: ""
+      X-B3-ParentSpanId: ""
+      X-B3-Sampled: ""
+      X-B3-SpanId: ""
+      X-B3-TraceId: ""
+      X-CF-Powered-By: ""
+      X-CMS: ""
+      X-Content-Encoded-By: ""
+      X-Envoy-Attempt-Count: ""
+      X-Envoy-External-Address: ""
+      X-Envoy-Internal: ""
+      X-Envoy-Original-Dst-Host: ""
+      X-Envoy-Upstream-Service-Time: ""
+      X-Framework: ""
+      X-Generated-By: ""
+      X-Generator: ""
+      X-LiteSpeed-Cache: ""
+      X-LiteSpeed-Purge: ""
+      X-LiteSpeed-Tag: ""
+      X-LiteSpeed-Vary: ""
+      X-Litespeed-Cache-Control: ""
+      X-Mod-Pagespeed: ""
+      X-Nextjs-Cache: ""
+      X-Nextjs-Matched-Path: ""
+      X-Nextjs-Page: ""
+      X-Nextjs-Redirect: ""
+      X-Old-Content-Length: ""
+      X-OneAgent-JS-Injection: ""
+      X-Page-Speed: ""
+      X-Php-Version: ""
+      X-Powered-By: ""
+      X-Powered-By-Plesk: ""
+      X-Powered-CMS: ""
+      X-Redirect-By: ""
+      X-Server-Powered-By: ""
+      X-SourceFiles: ""
+      X-SourceMap: ""
+      X-Turbo-Charged-By: ""
+      X-Umbraco-Version: ""
+      X-Varnish-Backend: ""
+      X-Varnish-Server: ""
+      X-dtAgentId: ""
+      X-dtHealthCheck: ""
+      X-dtInjectedServlet: ""
+      X-ruxit-JS-Agent: ""
+---
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: orch-platform-logs-node


### PR DESCRIPTION
Both App Service Proxy and VNC applications need this new `secure-headers-app-orch` middleware. So rather than repeating it in both places, it is better to centralize it here along side the main secure-headers.

You will see the `secure-headers-app-orch` has a CSP not as permissive as the main secure headers, as these extra src's are not needed.

Please note the Cross-Origin-Embedder-Policy is set to `unsafe-none` as Keycloak does not yet return a CORP header. This is planned for EMF 3.1 