### PR TITLE
Set proxy environment variables using build arguments

### DIFF
--- a/keycloak-tenant-controller/images/Dockerfile
+++ b/keycloak-tenant-controller/images/Dockerfile
@@ -9,10 +9,14 @@ ARG KTC_GIT_COMMIT
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
+ARG ftp_proxy
+ARG socks_proxy
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $http_proxy
 ENV NO_PROXY $http_proxy
+ENV FTP_PROXY $ftp_proxy
+ENV SOCKS_PROXY $socks_proxy
 
 COPY . /usr/src/keycloak-tenant-controller/
 WORKDIR /usr/src/keycloak-tenant-controller/

--- a/keycloak-tenant-controller/images/Dockerfile
+++ b/keycloak-tenant-controller/images/Dockerfile
@@ -5,6 +5,15 @@
 FROM golang:1.24.2 AS builder
 ARG KTC_GIT_COMMIT
 
+# Set proxy environment variables using build arguments
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+ENV HTTP_PROXY $http_proxy
+ENV HTTPS_PROXY $http_proxy
+ENV NO_PROXY $http_proxy
+
 COPY . /usr/src/keycloak-tenant-controller/
 WORKDIR /usr/src/keycloak-tenant-controller/
 


### PR DESCRIPTION
### Description

When using the make buildall target from the emf repo behind proxy, the curl command does not have access to the proxy settings even if the docker client is configured to work behind proxy. This change modifies the Dockerfile so that curl can run behind proxy.

Fixes # (issue)

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Locally behind proxy

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
