### PR TITLE
fix: Remove use of private SYS_ORCH_GITHUB Git token since repos are now public

### DIFF
--- a/.github/workflows/lint-test-build-publish.yml
+++ b/.github/workflows/lint-test-build-publish.yml
@@ -123,7 +123,6 @@ jobs:
           repository: open-edge-platform/orch-ci
           path: ci
           ref: main
-          token: ${{ secrets.SYS_ORCH_GITHUB }}
 
       - name: Run Version Check
         shell: bash
@@ -152,7 +151,6 @@ jobs:
           repository: open-edge-platform/orch-ci
           path: ci
           ref: main
-          token: ${{ secrets.SYS_ORCH_GITHUB }}
 
       - name: Setup asdf and install dependencies
         uses: ./.github/actions/setup-asdf
@@ -161,8 +159,6 @@ jobs:
       # We need to find a long term solution that leverages orch-ci workflow
       - name: Run Version Tag
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.SYS_ORCH_GITHUB }}
         shell: bash
         run: |
           # Tag the helm charts


### PR DESCRIPTION
### Description

The PAT stored in secrets.SYS_ORCH_GITHUB is no longer needed to be supplied to GHA workflows since all repos have migrated from private to public i.e. an authorized token is no longer needed to clone them.

Related to https://github.com/open-edge-platform/edge-manageability-framework/pull/274

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

If CI passes, we're good ✅

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
