### PR TITLE
fix nexus-api-gw unit tests env

### DIFF
--- a/nexus-api-gw/controllers/suite_test.go
+++ b/nexus-api-gw/controllers/suite_test.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -276,6 +277,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
 	})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 


### PR DESCRIPTION
### Description

The unit test in nexus-api-gw randomly fails as the api-server in envtest sometimes failed to bind 8080 port for metrics server. 
For the unit tests env the metric server is not required. This PR disable the metric server from envtests.
 

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
