### PR TITLE
Use official Photon base image for Nexus Openapi

### DIFF
--- a/nexus/openapi-generator/Dockerfile
+++ b/nexus/openapi-generator/Dockerfile
@@ -7,7 +7,7 @@ COPY . /app
 WORKDIR /app/openapi-generator
 RUN go mod tidy && go mod download && GOOS=linux GOARCH=amd64 go build -buildvcs=false -o bin/openapi-generator .
 
-FROM gcr.io/nsx-sm/photon:5.0
+FROM photon:5.0
 WORKDIR /bin
 COPY --from=builder /app/openapi-generator/bin/openapi-generator .
 USER 65532:65532


### PR DESCRIPTION
gcr.io/nsx-sm/photon:5.0 no longer exists. CI for orch-utils is failing as a result.
Switch to official image.

