### PR TITLE
ITEP-26789 ASP & VNC COEP Policy

### DIFF
--- a/cert-synchronizer/go.mod
+++ b/cert-synchronizer/go.mod
@@ -4,8 +4,9 @@
 
 module r53restapi.com
 
-go 1.22.0
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.27.1

--- a/charts/traefik-extra-objects/Chart.yaml
+++ b/charts/traefik-extra-objects/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v1
 description: A Helm chart for Traefik extra objects.
 name: traefik-extra-objects
-version: 4.1.10
+version: 4.1.11
 appVersion: "1.0.0"

--- a/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
+++ b/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
@@ -331,17 +331,50 @@ spec:
       X-Permitted-Cross-Domain-Policies: none
       Pragma: no-cache
       Cache-Control: "no-store, max-age=0"
-      Content-Security-Policy: "
-        default-src 'self'; form-action 'self';
-        object-src 'none'; frame-ancestors 'none';
-        script-src 'self' 'unsafe-eval' {{ required "A valid scriptSources entry required!" (join " " .Values.scriptSources) }};
-        style-src 'self' 'unsafe-inline'; img-src 'self' data:;
+      Content-Security-Policy: >-
+        block-all-mixed-content;
         connect-src 'self' {{ required "A valid connectCSP entry required!" (join " " .Values.connectCSPs) }};
-        upgrade-insecure-requests; block-all-mixed-content"
+        default-src 'self';
+        form-action 'self';
+        frame-ancestors 'none';
+        img-src 'self' data:;
+        object-src 'none';
+        script-src 'self' 'unsafe-eval' {{ required "A valid scriptSources entry required!" (join " " .Values.scriptSources) }};
+        style-src 'self' 'unsafe-inline';
+        upgrade-insecure-requests;
       Cross-Origin-Embedder-Policy: require-corp
       Cross-Origin-Opener-Policy: same-origin
       Cross-Origin-Resource-Policy: same-origin
-      Permissions-Policy: "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()"
+      Permissions-Policy: >-
+        accelerometer=(),
+        ambient-light-sensor=(),
+        autoplay=(),
+        battery=(),
+        camera=(),
+        display-capture=(),
+        document-domain=(),
+        encrypted-media=(),
+        fullscreen=(),
+        gamepad=(),
+        geolocation=(),
+        gyroscope=(),
+        layout-animations=(self),
+        legacy-image-formats=(self),
+        magnetometer=(),
+        microphone=(),
+        midi=(),
+        oversized-images=(self),
+        payment=(),
+        picture-in-picture=(),
+        publickey-credentials-get=(),
+        speaker-selection=(),
+        sync-xhr=(self),
+        unoptimized-images=(self),
+        unsized-media=(self),
+        usb=(),
+        screen-wake-lock=(),
+        web-share=(),
+        xr-spatial-tracking=()
       "$wsep": ""
       Host-Header: ""
       K-Proxy-Request: ""
@@ -415,18 +448,51 @@ spec:
       X-Permitted-Cross-Domain-Policies: none
       Pragma: no-cache
       Cache-Control: "no-store, max-age=0"
-      Content-Security-Policy: "
-        default-src 'self'; form-action 'self';
-        object-src 'none'; frame-ancestors 'none';
-        script-src 'self' ;
-        frame-src 'self' {{ required "A valid connectCSPsAppOrch entry required!" (join " " .Values.connectCSPsAppOrch) }};
-        style-src 'self'; img-src 'self' data:;
+      Content-Security-Policy: >-
+        block-all-mixed-content;
         connect-src 'self' {{ required "A valid connectCSPsAppOrch entry required!" (join " " .Values.connectCSPsAppOrch) }};
-        upgrade-insecure-requests; block-all-mixed-content"
+        default-src 'self';
+        form-action 'self';
+        frame-ancestors 'none';
+        frame-src 'self' {{ required "A valid connectCSPsAppOrch entry required!" (join " " .Values.connectCSPsAppOrch) }};
+        img-src 'self' data:;
+        object-src 'none';
+        script-src 'self';
+        style-src 'self';
+        upgrade-insecure-requests;
       Cross-Origin-Embedder-Policy: require-corp
       Cross-Origin-Opener-Policy: same-origin
       Cross-Origin-Resource-Policy: same-origin
-      Permissions-Policy: "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(self),legacy-image-formats=(self),magnetometer=(),microphone=(),midi=(),oversized-images=(self),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(self),unoptimized-images=(self),unsized-media=(self),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()"
+      Permissions-Policy: >-
+        accelerometer=(),
+        ambient-light-sensor=(),
+        autoplay=(),
+        battery=(),
+        camera=(),
+        display-capture=(),
+        document-domain=(),
+        encrypted-media=(),
+        fullscreen=(),
+        gamepad=(),
+        geolocation=(),
+        gyroscope=(),
+        layout-animations=(self),
+        legacy-image-formats=(self),
+        magnetometer=(),
+        microphone=(),
+        midi=(),
+        oversized-images=(self),
+        payment=(),
+        picture-in-picture=(),
+        publickey-credentials-get=(),
+        speaker-selection=(),
+        sync-xhr=(self),
+        unoptimized-images=(self),
+        unsized-media=(self),
+        usb=(),
+        screen-wake-lock=(),
+        web-share=(),
+        xr-spatial-tracking=()
       "$wsep": ""
       Host-Header: ""
       K-Proxy-Request: ""

--- a/nexus/compiler/example/datamodel/go.mod
+++ b/nexus/compiler/example/datamodel/go.mod
@@ -4,15 +4,20 @@
 
 module github.com/vmware-tanzu/graph-framework-for-microservices/compiler/example/datamodel
 
-go 1.16
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/elliotchance/orderedmap v1.8.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/vmware-tanzu/cartographer v1.2.0
 	github.com/vmware-tanzu/graph-framework-for-microservices/nexus v0.0.0-20230226005144-24336fc988d5
-	golang.org/x/term v0.30.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
+)
+
+require (
+	golang.org/x/term v0.30.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 )


### PR DESCRIPTION
### Description

This updates the secure headers for ASP and VNC `secure-headers-app-orch` middleware
a) To set on Cross-Origin-Embedder-Policy to `require-corp`
b) to make it more readable.

It also tidies up the CSP of the main `secure-headers` middleware to make it more readable.


Fixes # ITEP-26789

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

This has been tested by deploying and seeing that the tidied up headers remain the same, and that the changed COEP header is having the right effect when accessing Keycloak

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
