### PR TITLE
Increase Dependabot update freq. Auto-merge Dependabot PRs if they are updates to patch versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
-
   # Enable version updates for Go modules
   - package-ecosystem: "gomod"
     directories:
@@ -44,8 +43,14 @@ updates:
       - "/tenancy-manager"
       - "/tenancy-datamodel/test"
       - "/tenancy-datamodel"
+    # Only update patch versions to reduce the chance of regressions getting introduced
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "go.mod"
     reviewers:
@@ -95,8 +100,14 @@ updates:
       - "/charts/copy-secret"
       - "/charts/squid-proxy"
       - "/charts/oci-secret"
+    # Only update patch versions to reduce the chance of regressions getting introduced
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "Helm charts"
     reviewers:
@@ -120,8 +131,14 @@ updates:
       - "/tenancy-manager"
       - "/tenancy-datamodel"
       - "/squid-proxy"
+    # Only update patch versions to reduce the chance of regressions getting introduced
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "Dockerfile"
     reviewers:
@@ -131,8 +148,14 @@ updates:
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Only update patch versions to reduce the chance of regressions getting introduced
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "Github Actions"
     reviewers:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Dependabot auto-approve and auto-merge PR
+
+on:
+  # Trigger workflow on PRs to all branches
+  pull_request:
+    branches:
+      - "*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve Dependabot PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge for Dependabot PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### Description

- Change Dependabot updates from monthly to weekly.
- Automatically approve dependabot updates if they are updates to for patch versions.

Fixes # (issue)

### Any Newly Introduced Dependencies

- dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0 action

### How Has This Been Tested?

Needs to be merged to main branch before it can be tested.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
