### PR TITLE
[ITEP-21955] Removing  from UI CSP Header

### DIFF
--- a/charts/traefik-extra-objects/Chart.yaml
+++ b/charts/traefik-extra-objects/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v1
 description: A Helm chart for Traefik extra objects.
 name: traefik-extra-objects
-version: 4.1.11
+version: 4.1.12
 appVersion: "1.0.0"

--- a/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
+++ b/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
@@ -334,7 +334,7 @@ spec:
       Content-Security-Policy: "
         default-src 'self'; form-action 'self';
         object-src 'none'; frame-ancestors 'none';
-        script-src 'self' 'unsafe-eval' {{ required "A valid scriptSources entry required!" (join " " .Values.scriptSources) }};
+        script-src 'self' {{ required "A valid scriptSources entry required!" (join " " .Values.scriptSources) }};
         style-src 'self' 'unsafe-inline'; img-src 'self' data:;
         connect-src 'self' {{ required "A valid connectCSP entry required!" (join " " .Values.connectCSPs) }};
         upgrade-insecure-requests; block-all-mixed-content"


### PR DESCRIPTION
### Description

As per [ITEP-21955](https://jira.devtools.intel.com/browse/ITEP-21955) remove the `unsafe-eval` from the `script-src` directive in the CSP header used in the UI ingress route.

Fixes # ITEP-21955

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
