### PR TITLE
feat: Fixes and new API for OSUpdatePolicy and OSUpdateRun in api mapping

### DIFF
--- a/tenancy-api-mapping/apimappingconfigcrs/amc-infra-core-edge-infrastructure-manager-openapi-all.yaml
+++ b/tenancy-api-mapping/apimappingconfigcrs/amc-infra-core-edge-infrastructure-manager-openapi-all.yaml
@@ -12,7 +12,7 @@ spec:
   specGenEnabled: true
   repoConf:
     url: "https://github.com/open-edge-platform/infra-core.git"
-    tag: "apiv2/v2.1.3"
+    tag: "apiv2/v2.1.4"
     specFilePath: "apiv2/api/openapi/openapi.yaml"
   mappings:
     - externalURI: /v1/projects/{projectName}/regions
@@ -97,6 +97,14 @@ spec:
       serviceURI: edge-infra.orchestrator.apis/v2/customConfigs
     - externalURI: /v1/projects/{projectName}/customConfigs/{resourceId}
       serviceURI: edge-infra.orchestrator.apis/v2/customConfigs/{resourceId}
+    - externalURI: /v1/projects/{projectName}/os-update-policies
+      serviceURI: edge-infra.orchestrator.apis/v2/os_update_policy
+    - externalURI: /v1/projects/{projectName}/os-update-policies/{resourceId}
+      serviceURI: edge-infra.orchestrator.apis/v2/os_update_policy/{resourceId}
+    - externalURI: /v1/projects/{projectName}/os-update-runs
+      serviceURI: edge-infra.orchestrator.apis/v2/os_update_run
+    - externalURI: /v1/projects/{projectName}/os-update-runs/{resourceId}
+      serviceURI: edge-infra.orchestrator.apis/v2/os_update_run/{resourceId}
   backend:
     service: "apiv2-proxy.orch-infra.svc.cluster.local"
     port: 8080

--- a/tenancy-api-mapping/openapispecs/combined/combined_spec.yaml
+++ b/tenancy-api-mapping/openapispecs/combined/combined_spec.yaml
@@ -6023,11 +6023,11 @@ components:
           description: Inform if there are more elements
           title: has_next
           type: boolean
-        osUpdatePolicies:
-          description: Sorted and filtered list of os update policies.
+        osUpdateRuns:
+          description: Sorted and filtered list of os update runs.
           items:
             $ref: '#/components/schemas/OSUpdateRun'
-          title: os_update_policies
+          title: os_update_runs
           type: array
         totalElements:
           description: Count of items in the entire list, regardless of pagination.
@@ -6035,7 +6035,7 @@ components:
           title: total_elements
           type: integer
       required:
-        - osUpdatePolicies
+        - osUpdateRuns
         - totalElements
         - hasNext
       title: ListOSUpdateRunResponse
@@ -13622,6 +13622,324 @@ paths:
           description: OK
       tags:
         - MetadataService
+  /v1/projects/{projectName}/os-update-policies:
+    get:
+      description: Get a list of OS Update Policies.
+      operationId: OSUpdatePolicy_ListOSUpdatePolicy
+      parameters:
+        - description: |-
+            Optional comma separated list of fields to specify a sorting order.
+             See https://google.aip.dev/132 for details.
+          in: query
+          name: orderBy
+          schema:
+            description: |-
+              (OPTIONAL) Optional comma separated list of fields to specify a sorting order.
+               See https://google.aip.dev/132 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9., ]+$
+            title: order_by
+            type: string
+        - description: |-
+            Optional filter to return only item of interest.
+             See https://google.aip.dev/160 for details.
+          in: query
+          name: filter
+          schema:
+            description: |-
+              (OPTIONAL) Optional filter to return only item of interest.
+               See https://google.aip.dev/160 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9.,:/=*(){}"' ]+$
+            title: filter
+            type: string
+        - description: |-
+            Defines the amount of items to be contained in a single page.
+             Default of 20.
+          in: query
+          name: pageSize
+          schema:
+            description: |-
+              (OPTIONAL) Defines the amount of items to be contained in a single page.
+               Default of 20.
+            maximum: 100
+            minimum: 1
+            title: page_size
+            type: integer
+        - description: Index of the first item to return. This allows skipping items.
+          in: query
+          name: offset
+          schema:
+            description: (OPTIONAL) Index of the first item to return. This allows skipping items.
+            maximum: 10000
+            title: offset
+            type: integer
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOSUpdatePolicyResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: ListOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+    post:
+      description: Create an OS Update Policy.
+      operationId: OSUpdatePolicy_CreateOSUpdatePolicy
+      parameters:
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OSUpdatePolicy'
+        description: The OS Update policy to create.
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OSUpdatePolicy'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: CreateOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+  /v1/projects/{projectName}/os-update-policies/{resourceId}:
+    delete:
+      description: Delete a OS Update Policy.
+      operationId: OSUpdatePolicy_DeleteOSUpdatePolicy
+      parameters:
+        - description: Name of the OS Update Policy to be deleted.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the OS Update Policy to be deleted.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteOSUpdatePolicyResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: DeleteOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+    get:
+      description: Get a specific OS Update Policy.
+      operationId: OSUpdatePolicy_GetOSUpdatePolicy
+      parameters:
+        - description: Name of the requested os.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the requested os.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OSUpdatePolicy'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: GetOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+  /v1/projects/{projectName}/os-update-runs:
+    get:
+      description: Get a list of OS Update Policies.
+      operationId: OSUpdateRun_ListOSUpdateRun
+      parameters:
+        - description: |-
+            Optional comma separated list of fields to specify a sorting order.
+             See https://google.aip.dev/132 for details.
+          in: query
+          name: orderBy
+          schema:
+            description: |-
+              (OPTIONAL) Optional comma separated list of fields to specify a sorting order.
+               See https://google.aip.dev/132 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9., ]+$
+            title: order_by
+            type: string
+        - description: |-
+            Optional filter to return only item of interest.
+             See https://google.aip.dev/160 for details.
+          in: query
+          name: filter
+          schema:
+            description: |-
+              (OPTIONAL) Optional filter to return only item of interest.
+               See https://google.aip.dev/160 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9.,:/=*(){}"' ]+$
+            title: filter
+            type: string
+        - description: |-
+            Defines the amount of items to be contained in a single page.
+             Default of 20.
+          in: query
+          name: pageSize
+          schema:
+            description: |-
+              (OPTIONAL) Defines the amount of items to be contained in a single page.
+               Default of 20.
+            maximum: 100
+            minimum: 1
+            title: page_size
+            type: integer
+        - description: Index of the first item to return. This allows skipping items.
+          in: query
+          name: offset
+          schema:
+            description: (OPTIONAL) Index of the first item to return. This allows skipping items.
+            maximum: 10000
+            title: offset
+            type: integer
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOSUpdateRunResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: ListOSUpdateRun
+      tags:
+        - OSUpdateRun
+  /v1/projects/{projectName}/os-update-runs/{resourceId}:
+    delete:
+      description: Delete a OS Update Run.
+      operationId: OSUpdateRun_DeleteOSUpdateRun
+      parameters:
+        - description: Name of the os update run to be deleted.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the os update run to be deleted.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteOSUpdateRunResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: DeleteOSUpdateRun
+      tags:
+        - OSUpdateRun
+    get:
+      description: Get a specific OS Update Run.
+      operationId: OSUpdateRun_GetOSUpdateRun
+      parameters:
+        - description: Name of the requested os.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the requested os.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OSUpdateRun'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: GetOSUpdateRun
+      tags:
+        - OSUpdateRun
   /v1/projects/{projectName}/providers:
     get:
       description: Get a list of providers.

--- a/tenancy-api-mapping/openapispecs/generated/amc-infra-core-edge-infrastructure-manager-openapi-all.yaml
+++ b/tenancy-api-mapping/openapispecs/generated/amc-infra-core-edge-infrastructure-manager-openapi-all.yaml
@@ -2012,6 +2012,324 @@ paths:
       summary: ListLocations
       tags:
         - LocationService
+  /v1/projects/{projectName}/os-update-policies:
+    get:
+      description: Get a list of OS Update Policies.
+      operationId: OSUpdatePolicy_ListOSUpdatePolicy
+      parameters:
+        - description: |-
+            Optional comma separated list of fields to specify a sorting order.
+             See https://google.aip.dev/132 for details.
+          in: query
+          name: orderBy
+          schema:
+            description: |-
+              (OPTIONAL) Optional comma separated list of fields to specify a sorting order.
+               See https://google.aip.dev/132 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9., ]+$
+            title: order_by
+            type: string
+        - description: |-
+            Optional filter to return only item of interest.
+             See https://google.aip.dev/160 for details.
+          in: query
+          name: filter
+          schema:
+            description: |-
+              (OPTIONAL) Optional filter to return only item of interest.
+               See https://google.aip.dev/160 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9.,:/=*(){}"' ]+$
+            title: filter
+            type: string
+        - description: |-
+            Defines the amount of items to be contained in a single page.
+             Default of 20.
+          in: query
+          name: pageSize
+          schema:
+            description: |-
+              (OPTIONAL) Defines the amount of items to be contained in a single page.
+               Default of 20.
+            maximum: 100
+            minimum: 1
+            title: page_size
+            type: integer
+        - description: Index of the first item to return. This allows skipping items.
+          in: query
+          name: offset
+          schema:
+            description: (OPTIONAL) Index of the first item to return. This allows skipping items.
+            maximum: 10000
+            title: offset
+            type: integer
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOSUpdatePolicyResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: ListOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+    post:
+      description: Create an OS Update Policy.
+      operationId: OSUpdatePolicy_CreateOSUpdatePolicy
+      parameters:
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OSUpdatePolicy'
+        description: The OS Update policy to create.
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OSUpdatePolicy'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: CreateOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+  /v1/projects/{projectName}/os-update-policies/{resourceId}:
+    delete:
+      description: Delete a OS Update Policy.
+      operationId: OSUpdatePolicy_DeleteOSUpdatePolicy
+      parameters:
+        - description: Name of the OS Update Policy to be deleted.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the OS Update Policy to be deleted.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteOSUpdatePolicyResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: DeleteOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+    get:
+      description: Get a specific OS Update Policy.
+      operationId: OSUpdatePolicy_GetOSUpdatePolicy
+      parameters:
+        - description: Name of the requested os.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the requested os.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OSUpdatePolicy'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: GetOSUpdatePolicy
+      tags:
+        - OSUpdatePolicy
+  /v1/projects/{projectName}/os-update-runs:
+    get:
+      description: Get a list of OS Update Policies.
+      operationId: OSUpdateRun_ListOSUpdateRun
+      parameters:
+        - description: |-
+            Optional comma separated list of fields to specify a sorting order.
+             See https://google.aip.dev/132 for details.
+          in: query
+          name: orderBy
+          schema:
+            description: |-
+              (OPTIONAL) Optional comma separated list of fields to specify a sorting order.
+               See https://google.aip.dev/132 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9., ]+$
+            title: order_by
+            type: string
+        - description: |-
+            Optional filter to return only item of interest.
+             See https://google.aip.dev/160 for details.
+          in: query
+          name: filter
+          schema:
+            description: |-
+              (OPTIONAL) Optional filter to return only item of interest.
+               See https://google.aip.dev/160 for details.
+            maxLength: 1000
+            pattern: ^$|^[a-zA-Z-_0-9.,:/=*(){}"' ]+$
+            title: filter
+            type: string
+        - description: |-
+            Defines the amount of items to be contained in a single page.
+             Default of 20.
+          in: query
+          name: pageSize
+          schema:
+            description: |-
+              (OPTIONAL) Defines the amount of items to be contained in a single page.
+               Default of 20.
+            maximum: 100
+            minimum: 1
+            title: page_size
+            type: integer
+        - description: Index of the first item to return. This allows skipping items.
+          in: query
+          name: offset
+          schema:
+            description: (OPTIONAL) Index of the first item to return. This allows skipping items.
+            maximum: 10000
+            title: offset
+            type: integer
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListOSUpdateRunResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: ListOSUpdateRun
+      tags:
+        - OSUpdateRun
+  /v1/projects/{projectName}/os-update-runs/{resourceId}:
+    delete:
+      description: Delete a OS Update Run.
+      operationId: OSUpdateRun_DeleteOSUpdateRun
+      parameters:
+        - description: Name of the os update run to be deleted.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the os update run to be deleted.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteOSUpdateRunResponse'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: DeleteOSUpdateRun
+      tags:
+        - OSUpdateRun
+    get:
+      description: Get a specific OS Update Run.
+      operationId: OSUpdateRun_GetOSUpdateRun
+      parameters:
+        - description: Name of the requested os.
+          in: path
+          name: resourceId
+          required: true
+          schema:
+            description: Name of the requested os.
+            title: resourceId
+            type: string
+        - description: unique projectName for the resource
+          in: path
+          name: projectName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OSUpdateRun'
+          description: Success
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+          description: Error
+      summary: GetOSUpdateRun
+      tags:
+        - OSUpdateRun
   /v1/projects/{projectName}/providers:
     get:
       description: Get a list of providers.
@@ -6648,11 +6966,11 @@ components:
           description: Inform if there are more elements
           title: has_next
           type: boolean
-        osUpdatePolicies:
-          description: Sorted and filtered list of os update policies.
+        osUpdateRuns:
+          description: Sorted and filtered list of os update runs.
           items:
             $ref: '#/components/schemas/OSUpdateRun'
-          title: os_update_policies
+          title: os_update_runs
           type: array
         totalElements:
           description: Count of items in the entire list, regardless of pagination.
@@ -6660,7 +6978,7 @@ components:
           title: total_elements
           type: integer
       required:
-        - osUpdatePolicies
+        - osUpdateRuns
         - totalElements
         - hasNext
       title: ListOSUpdateRunResponse


### PR DESCRIPTION
Main changes:
- Update APIv2 to v2.1.4
- New API for OSUpdatePolicy allowing Create, Read, List and Delete
- New API for OSUpdaeteRun allowing Read, List Delete

### Updates to OpenAPI Specifications:

#### New Endpoints for OS Update Policies and Runs:
* Added endpoints for managing OS update policies (`/v1/projects/{projectName}/os-update-policies`) and OS update runs (`/v1/projects/{projectName}/os-update-runs`), including operations for listing, creating, retrieving, and deleting resources.

#### Schema Modifications:
* Renamed `configContent` to `config` in the `CustomConfigResource` schema and updated related properties and requirements.
* Changed the maximum length of the `name` property in `CustomConfigResource` from 32 to 40 characters.

#### Pattern Updates:
* Adjusted patterns for various string properties to improve validation, including escaping special characters and ensuring compatibility with JSON encoding. Examples include `existingCves`, `osUpdateAvailable`, and `runtimePackages`.

#### Other Enhancements:
* Added new enum value `POWER_STATE_POWER_CYCLE` to the `PowerState` schema.
* Introduced `maxItems` constraints for array properties like `update_sources` to limit the number of items.

These updates improve the API's functionality, validation, and usability for managing OS-related resources.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes
- [X] I have not introduced any 3rd party dependency changes
- [X] I have performed a self-review of my code
