### PR TITLE
Fix for codeql scan errors on nexus api gateway code

### DIFF
--- a/nexus-api-gw/pkg/openapi/declarative/handler.go
+++ b/nexus-api-gw/pkg/openapi/declarative/handler.go
@@ -74,10 +74,10 @@ func ListHandler(c echo.Context) error {
 	}
 
 	// Execute the request
-	resp, err := httpClient.Do(req)
+	resp, err := executeRequestWithoutCtxt(c, req)
 	if err != nil {
 		log.Warn().Msg(err.Error())
-		return c.NoContent(http.StatusInternalServerError)
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -117,10 +117,10 @@ func GetHandler(c echo.Context) error {
 	}
 
 	// Execute the request
-	resp, err := httpClient.Do(req)
+	resp, err := executeRequestWithoutCtxt(c, req)
 	if err != nil {
 		log.Warn().Msg(err.Error())
-		return c.NoContent(http.StatusInternalServerError)
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -231,6 +231,17 @@ func executeRequest(c echo.Context, req *http.Request) error {
 	return c.JSON(resp.StatusCode, respBody)
 }
 
+func executeRequestWithoutCtxt(c echo.Context, req *http.Request) (*http.Response, error) {
+	log.Debug().Msgf("Making a request to: %s", req.URL.String())
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Warn().Msg(err.Error())
+		return nil, c.NoContent(http.StatusInternalServerError)
+	}
+	return resp, nil
+}
+
 func DeleteHandler(c echo.Context) error {
 	ec, ok := c.(*EndpointContext)
 	if !ok {
@@ -256,11 +267,10 @@ func DeleteHandler(c echo.Context) error {
 
 	log.Debug().Msgf("Making a request to: %s", url)
 
-	httpClient := &http.Client{}
-	resp, err := httpClient.Do(req)
+	resp, err := executeRequestWithoutCtxt(c, req)
 	if err != nil {
 		log.InfraErr(err).Msg("")
-		return c.NoContent(http.StatusInternalServerError)
+		return err
 	}
 	defer resp.Body.Close()
 	return c.NoContent(resp.StatusCode)


### PR DESCRIPTION
### Description

Fix for codeql scan errors on nexus api gateway code

Fixes # (issue) 
Fixes following issues: 
https://github.com/open-edge-platform/orch-utils/security/code-scanning/14
https://github.com/open-edge-platform/orch-utils/security/code-scanning/15
https://github.com/open-edge-platform/orch-utils/security/code-scanning/16

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

By executing code ql scanner

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
