### PR TITLE
Trivy ignore readOnlyRootFilesystem and security contexts

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -22,3 +22,23 @@ misconfigurations:
     paths:
       - "auth-service/Dockerfile"
     statement: Scratch images have no user. USER command would break the image.
+
+  - id: AVD-KSV-0014
+    paths:
+      - "charts/adm-secret/templates/job.yaml"
+      - "charts/auth-service/templates/deployment.yaml"
+      - "charts/deployment-wait/templates/job.yaml"
+      - "charts/keycloak-tenant-controller/templates/statefulset.yaml"
+      - "charts/secret-wait/templates/job.yaml"
+      - "charts/statefulset-wait/templates/job.yaml"
+      - "charts/token-fs/templates/deployment.yaml"
+      - "charts/vertical-pod-autoscaler/templates/deployment.yaml"
+    statement: readOnlyRootFilesystem is injected by Kyverno policy in charts/kyverno-extra-policies/templates/restricted-policy-orch.yaml
+
+  - id: AVD-KSV-0118
+    paths:
+      - "charts/adm-secret/templates/job.yaml"
+      - "charts/token-fs/templates/deployment.yaml"
+      - "charts/auth-service/templates/deployment.yaml"
+      - "charts/k8s-metrics-server/templates/components.yaml"
+    statement: Security context is injected by Kyverno policy in charts/kyverno-extra-policies/templates/restricted-policy-orch.yaml


### PR DESCRIPTION
These policies are later injected by Kyverno, so Trivy should not be flagging them in these scans.

See charts/kyverno-extra-policies/templates/restricted-policy-orch.yaml

### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
