### PR TITLE
add back and update the openapi-gen dependency

### DIFF
--- a/nexus/compiler/builder/Dockerfile
+++ b/nexus/compiler/builder/Dockerfile
@@ -32,7 +32,7 @@ RUN git config --global --add safe.directory '*' \
     && go install github.com/onsi/gomega/...@v1.18.0 \
     && go install golang.org/x/tools/cmd/goimports@latest \
     && go install github.com/mikefarah/yq/v4@v4.45.1 \
-    #&& go install -buildvcs=false k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20250304201544-e5f78fe3ede9
+    && go install -buildvcs=false k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20250909170358-d67c058d9372 \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.64.6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Description

This PR adds back the openapi-gen dependency removed from the Dockerfile of nexus compiler.

Fixes # (issue)

### Any Newly Introduced Dependencies

openapi-gen

### How Has This Been Tested?

manually.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
