### PR TITLE
Add annotations to the other secrets

### DIFF
--- a/charts/postgresql-secrets/Chart.yaml
+++ b/charts/postgresql-secrets/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 25.2.2
+version: 25.2.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/postgresql-secrets/templates/secrets.yaml
+++ b/charts/postgresql-secrets/templates/secrets.yaml
@@ -13,6 +13,10 @@ kind: Secret
 metadata:
   name: {{ $v.name }}-local-postgresql
   namespace: {{ $v.namespace }}
+  {{- with $.Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     managed-by: edge-manageability-framework
 stringData:
@@ -32,6 +36,10 @@ kind: Secret
 metadata:
   name: {{ $v.name }}-reader-local-postgresql
   namespace: {{ $v.namespace }}
+  {{- with $.Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     managed-by: edge-manageability-framework
 stringData:


### PR DESCRIPTION
### Description

This adds the ability to add annotations to the rest of the postgresql-secrets. 

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

locally and ci

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
