### PR TITLE
fix(component-status): add cors middleware to IngressRoute and expose Date header

### DIFF
--- a/charts/component-status/Chart.yaml
+++ b/charts/component-status/Chart.yaml
@@ -8,4 +8,4 @@ name: component-status
 description: A Helm chart for the Orchestrator Component Status Service
 type: application
 version: 26.1.2
-appVersion: "26.1.1"
+appVersion: "26.1.2"

--- a/charts/component-status/Chart.yaml
+++ b/charts/component-status/Chart.yaml
@@ -7,5 +7,5 @@ apiVersion: v2
 name: component-status
 description: A Helm chart for the Orchestrator Component Status Service
 type: application
-version: 26.1.1
+version: 26.1.2
 appVersion: "26.1.1"

--- a/charts/component-status/values.yaml
+++ b/charts/component-status/values.yaml
@@ -98,6 +98,7 @@ traefikRoute:
   tlsOption: ""
   middlewares:
     - validate-jwt
+    - cors
     - secure-headers
 
 # Component Status Configuration

--- a/charts/traefik-extra-objects/Chart.yaml
+++ b/charts/traefik-extra-objects/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v1
 description: A Helm chart for Traefik extra objects.
 name: traefik-extra-objects
-version: 26.0.3
-appVersion: "26.0.0"
+version: 26.1.0
+appVersion: "26.1.0"

--- a/charts/traefik-extra-objects/Chart.yaml
+++ b/charts/traefik-extra-objects/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v1
 description: A Helm chart for Traefik extra objects.
 name: traefik-extra-objects
-version: 26.0.2
+version: 26.0.3
 appVersion: "26.0.0"

--- a/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
+++ b/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml
@@ -81,6 +81,8 @@ spec:
       - {{ $origin }}
     {{- end }}
     accessControlAllowCredentials: true
+    accessControlExposeHeaders:
+      - "Date"
     accessControlMaxAge: 100
     addVaryHeader: true
     stsSeconds: 31536000


### PR DESCRIPTION
### Description

Changes required for the orchestrator clock feature:

1. `charts/component-status/values.yaml` Add 'cors' to the IngressRoute middleware list so the browser receives Access-Control-Allow-Origin and can complete the CORS preflight for /v1/orchestrator.  Without this the fetch was blocked and the clock fell back to local time.

2. `charts/traefik-extra-objects/templates/traefik-extra-objects.yaml` Add accessControlExposeHeaders: [Date] to the cors Middleware spec. Traefik manages all Access-Control-* headers centrally; the app-level header was stripped. This allows the browser's JS to read the Date header from the response so useOrchestratorTime can anchor to real orchestrator time.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
