### PR TITLE
Fix request body limit enforcement

### DIFF
--- a/tenancy-manager/internal/api/api.go
+++ b/tenancy-manager/internal/api/api.go
@@ -144,7 +144,9 @@ func (h *Handler) CreateOrUpdateOrg(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Description string `json:"description"`
 	}
-	decodeBody(w, r, &body) // description is optional; empty body is valid
+	if !decodeBody(w, r, &body) { // description is optional; empty body is valid
+		return
+	}
 
 	updateIfExists := r.URL.Query().Get("update_if_exists") != "false" // default true
 
@@ -277,7 +279,9 @@ func (h *Handler) CreateOrUpdateProject(w http.ResponseWriter, r *http.Request) 
 	var body struct {
 		Description string `json:"description"`
 	}
-	decodeBody(w, r, &body) // description is optional; empty body is valid
+	if !decodeBody(w, r, &body) { // description is optional; empty body is valid
+		return
+	}
 
 	updateIfExists := r.URL.Query().Get("update_if_exists") != "false" // default true
 

--- a/tenancy-manager/tests/integration/run.sh
+++ b/tenancy-manager/tests/integration/run.sh
@@ -40,6 +40,10 @@ TM_PORT=18080
 TM_BIN="${REPO_DIR}/bin/tenancy-manager"
 TM_PID=""
 
+SNAP_LIVE="/tmp/tm-snap-live.txt"
+SNAP_PROJ_DEL="/tmp/tm-snap-proj-del.txt"
+SNAP_ORG_DEL="/tmp/tm-snap-org-del.txt"
+
 SKIP_BUILD=false
 [[ "${1:-}" == "--skip-build" ]] && SKIP_BUILD=true
 
@@ -92,6 +96,25 @@ wait_for() {
     done
     err "${desc} did not become ready after ${retries}s"
     return 1
+}
+
+# pg_snapshot captures a full DB state into a file silently (no output during tests).
+pg_snapshot() {
+    local file="$1"
+    local psql_cmd="docker exec ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_DB} -x"
+    (
+        echo "=== orgs ==="
+        ${psql_cmd} -c "SELECT id, name, description, created_at, updated_at, deleted_at FROM orgs ORDER BY created_at;" || true
+        echo ""
+        echo "=== folders ==="
+        ${psql_cmd} -c "SELECT id, name, org_folders AS org_id, created_at, updated_at FROM folders ORDER BY created_at;" || true
+        echo ""
+        echo "=== projects ==="
+        ${psql_cmd} -c "SELECT id, name, description, folder_projects AS folder_id, created_at, updated_at, deleted_at FROM projects ORDER BY created_at;" || true
+        echo ""
+        echo "=== tenancy_events ==="
+        ${psql_cmd} -c "SELECT id, event_type, resource_type, resource_name, org_name, folder_id, created_at FROM tenancy_events ORDER BY id;" || true
+    ) > "${file}"
 }
 
 TM="http://localhost:${TM_PORT}"
@@ -162,7 +185,7 @@ step "Org CRUD"
 check "PUT /v1/orgs/test-org → 200 (create)" \
     "200" "$(curl -so /dev/null -w '%{http_code}' \
         -X PUT -H 'Content-Type: application/json' \
-        -d '{"description":"integration test org"}' \
+        -d '{"description":"description set on create"}' \
         "${TM}/v1/orgs/test-org")"
 
 check "GET /v1/orgs/test-org → 200" \
@@ -172,7 +195,7 @@ check "GET /v1/orgs/test-org body contains name" \
     '"name":"test-org"' "$(curl -s "${TM}/v1/orgs/test-org")"
 
 check "GET /v1/orgs/test-org body contains description" \
-    '"description":"integration test org"' "$(curl -s "${TM}/v1/orgs/test-org")"
+    '"description":"description set on create"' "$(curl -s "${TM}/v1/orgs/test-org")"
 
 check "GET /v1/orgs → list includes test-org" \
     "test-org" "$(curl -s "${TM}/v1/orgs")"
@@ -180,11 +203,11 @@ check "GET /v1/orgs → list includes test-org" \
 check "PUT /v1/orgs/test-org → 200 (update description)" \
     "200" "$(curl -so /dev/null -w '%{http_code}' \
         -X PUT -H 'Content-Type: application/json' \
-        -d '{"description":"updated"}' \
+        -d '{"description":"description updated to test update path"}' \
         "${TM}/v1/orgs/test-org")"
 
 check "GET /v1/orgs/test-org body has updated description" \
-    '"description":"updated"' "$(curl -s "${TM}/v1/orgs/test-org")"
+    '"description":"description updated to test update path"' "$(curl -s "${TM}/v1/orgs/test-org")"
 
 step "Project CRUD"
 check "PUT /v1/projects/test-proj?org=test-org → 200 (create)" \
@@ -202,9 +225,13 @@ check "GET /v1/projects/test-proj body contains name" \
 check "GET /v1/projects → list includes test-proj" \
     "test-proj" "$(curl -s "${TM}/v1/projects")"
 
+pg_snapshot "${SNAP_LIVE}"
+
 check "DELETE /v1/projects/test-proj?org=test-org → 200" \
     "200" "$(curl -so /dev/null -w '%{http_code}' \
         -X DELETE "${TM}/v1/projects/test-proj?org=test-org")"
+
+pg_snapshot "${SNAP_PROJ_DEL}"
 
 step "Error handling"
 check "GET /v1/orgs/does-not-exist → 404" \
@@ -245,6 +272,35 @@ step "Cleanup test data"
 check "DELETE /v1/orgs/test-org → 200" \
     "200" "$(curl -so /dev/null -w '%{http_code}' \
         -X DELETE "${TM}/v1/orgs/test-org")"
+
+pg_snapshot "${SNAP_ORG_DEL}"
+
+step "DB State History"
+TERM_WIDTH=$(tput cols 2>/dev/null || echo 200)
+COL=$(( (TERM_WIDTH - 6) / 3 ))
+(( COL < 60 )) && COL=60
+SEP=$(printf '%*s' "$(( COL * 3 + 6 ))" '' | tr ' ' '-')
+
+# Pad a file to a target line count so paste produces aligned columns.
+pad_to() {
+    local file="$1" target="$2"
+    local cur; cur=$(wc -l < "$file")
+    cat "$file"
+    for (( i=cur; i<target; i++ )); do printf '\n'; done
+}
+MAX_LINES=$(wc -l < "${SNAP_ORG_DEL}")  # longest snapshot is always the last
+
+printf "${CYAN}%-*s${NC} | ${CYAN}%-*s${NC} | ${CYAN}%-*s${NC}\n" \
+    "$COL" "1. After project create" \
+    "$COL" "2. After project delete" \
+    "$COL" "3. After org delete"
+echo "${SEP}"
+
+paste \
+    <(pad_to "${SNAP_LIVE}"     "$MAX_LINES" | awk -v w="$COL" '{printf "%-*.*s\n", w, w, $0}') \
+    <(pad_to "${SNAP_PROJ_DEL}" "$MAX_LINES" | awk -v w="$COL" '{printf "%-*.*s\n", w, w, $0}') \
+    <(pad_to "${SNAP_ORG_DEL}"  "$MAX_LINES" | awk -v w="$COL" '{printf "%-*.*s\n", w, w, $0}') \
+    | sed 's/	/ | /g'
 
 # Final result is printed by the cleanup trap.
 [[ ${FAIL} -eq 0 ]]


### PR DESCRIPTION
- decodeBody() return value was ignored in CreateOrUpdateOrg and CreateOrUpdateProject. A body exceeding the limit would correctly receive a 400 response, but the handler would then continue and create the resource anyway. Now returns immediately on decode failure.

- Some enhancements to integration test - show DB status at different stages

### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
