### PR TITLE
Fix postgres url construction in tenancy-manager

### DIFF
--- a/tenancy-manager/internal/config/config.go
+++ b/tenancy-manager/internal/config/config.go
@@ -5,7 +5,6 @@
 package config
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"time"
@@ -118,8 +117,16 @@ func databaseURLFromEnv() string {
 	if sslmode == "" {
 		sslmode = "disable"
 	}
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		user, password, host, port, dbName, sslmode)
+	u := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, password),
+		Host:   host + ":" + port,
+		Path:   "/" + dbName,
+	}
+	q := u.Query()
+	q.Set("sslmode", sslmode)
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // RedactedDatabaseURL returns the database URL with the password replaced by


### PR DESCRIPTION
Use url.URL and url.UserPassword instead of fmt.Sprintf so that passwords containing special chars are percent-encoded correctly.

### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
