### PR TITLE
Potential fix for code scanning alert no. 694: Reflected cross-site scripting

### DIFF
--- a/cert-synchronizer/pkg/apiserver/server.go
+++ b/cert-synchronizer/pkg/apiserver/server.go
@@ -10,6 +10,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
@@ -2987,7 +2988,7 @@ func (r httpResponse) write(writer http.ResponseWriter) {
 	log.Infof("apiserver->httpResponse write()->start")
 	log.Infof("Writing HTTP response")
 	var (
-		body        = []byte(r.message)
+		body        = []byte(html.EscapeString(r.message))
 		contentType = PLAIN_CONTENT
 		err         error
 	)

--- a/charts/cert-synchronizer/Chart.yaml
+++ b/charts/cert-synchronizer/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v2
 name: cert-synchronizer
 type: application
-version: 26.1.14
-appVersion: "26.1.14"
+version: 26.1.15
+appVersion: "26.1.15"

--- a/charts/cert-synchronizer/Chart.yaml
+++ b/charts/cert-synchronizer/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v2
 name: cert-synchronizer
 type: application
-version: 26.1.13
-appVersion: "26.1.13"
+version: 26.1.14
+appVersion: "26.1.14"


### PR DESCRIPTION
Potential fix for [https://github.com/open-edge-platform/orch-utils/security/code-scanning/694](https://github.com/open-edge-platform/orch-utils/security/code-scanning/694)

General fix: ensure any user-influenced string written into HTTP responses is safely encoded for the response context. For this codebase, the safest minimal fix is to HTML-escape response message content right before writing it in `httpResponse.write` in `cert-synchronizer/pkg/apiserver/server.go`, so all variants are covered through one choke point.

Best single fix (without changing functional flow):  
- In `cert-synchronizer/pkg/apiserver/server.go` import Go stdlib `html`.  
- In `httpResponse.write` (around lines 2988–2991), replace direct `[]byte(r.message)` with `[]byte(html.EscapeString(r.message))`.  
This preserves the same message text semantics while neutralizing script injection payloads in reflected content. No changes are needed in `component-status/cmd/component-status/main.go` because that wrapper should remain a transparent writer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
