### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/lint-test-build-publish.yml
+++ b/.github/workflows/lint-test-build-publish.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
   # Trigger workflow on PRs to all branches
   pull_request:


### PR DESCRIPTION
This pull request includes a small update to the GitHub Actions workflow configuration. The change ensures that the workflow is triggered not only on pushes to the `main` branch but also on pushes to any tag.

- [`.github/workflows/lint-test-build-publish.yml`](diffhunk://#diff-e08be60351ad763aa3ef28fa56e098237d74bd75613fc9f4a7e2e9a27580afd0R14-R15): Updated the `push` trigger to include all tags, so the workflow runs on tag pushes as well as on pushes to `main`.