### PR TITLE
Remove trigger on tag from workflow

### DIFF
--- a/.github/workflows/lint-test-build-publish.yml
+++ b/.github/workflows/lint-test-build-publish.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
 
   # Trigger workflow on PRs to all branches
   pull_request:


### PR DESCRIPTION
This pull request makes a minor update to the workflow trigger configuration in `.github/workflows/lint-test-build-publish.yml`. The change removes the trigger that ran the workflow on all tag pushes, so the workflow will now only run on pushes to the `main` branch and on pull requests.

([.github/workflows/lint-test-build-publish.ymlL14-L15](diffhunk://#diff-e08be60351ad763aa3ef28fa56e098237d74bd75613fc9f4a7e2e9a27580afd0L14-L15))