### PR TITLE
Potential fix for code scanning alert no. 694: Reflected cross-site scripting

### DIFF
--- a/cert-synchronizer/pkg/apiserver/server.go
+++ b/cert-synchronizer/pkg/apiserver/server.go
@@ -3022,7 +3022,7 @@ func (r httpResponse) write(writer http.ResponseWriter) {
 		if body, err = os.ReadFile(r.errWebpagePath); err != nil {
 			log.Errorf("Error reading HTML file: %v", err)
 			log.Errorf("Attempting plain text response")
-			body = []byte(r.message)
+			body = []byte(html.EscapeString(r.message))
 		} else {
 			contentType = HTML_CONTENT
 

--- a/charts/cert-synchronizer/Chart.yaml
+++ b/charts/cert-synchronizer/Chart.yaml
@@ -6,5 +6,5 @@
 apiVersion: v2
 name: cert-synchronizer
 type: application
-version: 26.1.18
-appVersion: "26.1.18"
+version: 26.1.19
+appVersion: "26.1.19"


### PR DESCRIPTION
Potential fix for [https://github.com/open-edge-platform/orch-utils/security/code-scanning/694](https://github.com/open-edge-platform/orch-utils/security/code-scanning/694)

General fix: ensure any user-influenced data written to HTTP responses is encoded for the output context (HTML/text) on every path, including fallback/error paths.

Best minimal fix in shown code: in `cert-synchronizer/pkg/apiserver/server.go`, update `httpResponse.write` so the fallback branch after `os.ReadFile` failure uses escaped content (`html.EscapeString`) instead of raw `r.message`. This preserves behavior (still returns message text) while removing reflected XSS risk. No functional routing or business logic changes are needed.

Specific region to change:
- `cert-synchronizer/pkg/apiserver/server.go`, inside `func (r httpResponse) write(writer http.ResponseWriter)` around lines 3022–3026.
- No new imports required (`html` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
