### PR TITLE
fix(tenancy-manager): add periodic cleanup for stale controller statuses

### DIFF
--- a/tenancy-manager/cmd/main.go
+++ b/tenancy-manager/cmd/main.go
@@ -167,6 +167,13 @@ func runCleanup(ctx context.Context, s *store.Store, cfg *config.Config) {
 				log.Info().Int("count", n).Msg("cleaned up old events")
 			}
 
+			// Clean up stale controller_status entries for deleted resources
+			// This fixes the bug where status deletion failures leave entries that
+			// prevent new project creation
+			if err := s.CleanupStaleControllerStatuses(ctx); err != nil {
+				log.Warn().Err(err).Msg("stale status cleanup failed")
+			}
+
 			if err := s.CleanupHardDelete(ctx, cfg); err != nil {
 				log.Warn().Err(err).Msg("hard-delete cleanup failed")
 			}

--- a/tenancy-manager/internal/store/store.go
+++ b/tenancy-manager/internal/store/store.go
@@ -845,6 +845,61 @@ func (s *Store) CleanupOldEvents(ctx context.Context, retention time.Duration) (
 		Exec(ctx)
 }
 
+// CleanupStaleControllerStatuses removes controller_status entries for
+// deleted projects/orgs that are stuck (in_progress or completed status
+// persisting after deletion event was processed). This fixes the bug where
+// status deletion failures leave stale entries that prevent new project creation.
+func (s *Store) CleanupStaleControllerStatuses(ctx context.Context) error {
+	// Find deleted projects with lingering controller_status entries
+	deletedProjects, err := s.client.Project.Query().
+		Where(project.DeletedAtNotNil()).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range deletedProjects {
+		// Delete ALL controller_status entries for deleted projects
+		// Controllers should have removed these when processing the deletion event,
+		// but if they failed (network/DB glitch), we clean them up here
+		n, err := s.client.ControllerStatus.Delete().
+			Where(
+				controllerstatus.ResourceType("project"),
+				controllerstatus.ResourceID(p.ID),
+			).
+			Exec(ctx)
+		if err != nil {
+			log.Warn().Err(err).Str("project", p.Name).Msg("failed to cleanup stale controller statuses")
+		} else if n > 0 {
+			log.Info().Str("project", p.Name).Int("count", n).Msg("cleaned up stale controller statuses for deleted project")
+		}
+	}
+
+	// Find deleted orgs with lingering controller_status entries
+	deletedOrgs, err := s.client.Org.Query().
+		Where(org.DeletedAtNotNil()).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, o := range deletedOrgs {
+		n, err := s.client.ControllerStatus.Delete().
+			Where(
+				controllerstatus.ResourceType("org"),
+				controllerstatus.ResourceID(o.ID),
+			).
+			Exec(ctx)
+		if err != nil {
+			log.Warn().Err(err).Str("org", o.Name).Msg("failed to cleanup stale controller statuses")
+		} else if n > 0 {
+			log.Info().Str("org", o.Name).Int("count", n).Msg("cleaned up stale controller statuses for deleted org")
+		}
+	}
+
+	return nil
+}
+
 // CleanupHardDelete hard-deletes soft-deleted resources that have no
 // controller_statuses rows from registered controllers.
 func (s *Store) CleanupHardDelete(ctx context.Context, cfg *config.Config) error {


### PR DESCRIPTION
Add CleanupStaleControllerStatuses() function to remove controller_status entries for deleted projects/orgs. These entries should be removed when controllers process deletion events, but if the status deletion fails, stale entries remain in the database.

The bug manifests as:
1. Project deleted successfully (soft-deleted in projects table)
2. Controller processes deletion but fails to delete controller_status row
3. Stale in_progress/completed status remains for deleted project UUID
4. New project creation gets stuck waiting for non-existent controller

Fix: Run periodic cleanup (using existing cleanup interval) to remove ALL controller_status entries for any project/org that has been soft-deleted (deleted_at IS NOT NULL). This ensures the database stays clean even when controllers fail to clean up properly.

The cleanup runs alongside existing CleanupOldEvents and CleanupHardDelete operations, using the same CleanupInterval configuration.

Resolves: Project creation stuck after deletion with stale controller_status

### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
